### PR TITLE
[docs] Small `sed` cmd for  `oh-my-zsh` plugin

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,10 +66,10 @@ Clone k into your custom plugins repo
 ```shell
 git clone https://github.com/supercrabtree/k $ZSH_CUSTOM/plugins/k
 ```
-Then load as a plugin in your `.zshrc`
+Then load as a plugin in your `.zshrc`. If `plugins` is where it usually is:
 
 ```shell
-plugins+=(k)
+sed -i 's/^plugins=(/plugins=(k /g' $HOME/.zshrc
 ```
 
 ### Manually


### PR DESCRIPTION
I added a small `sed` command that changes the `.zshrc` file. I think this is an improvement over the `plugins+=` syntax, which you can't just copy and paste into a terminal and expect to work.